### PR TITLE
Fixed Service type and subtype checks. New queries on catalog for getting by type/subtype

### DIFF
--- a/src/common/CatalogRequest.py
+++ b/src/common/CatalogRequest.py
@@ -77,6 +77,7 @@ class CatalogRequest:
 
     def _check_mqtt_endpoint(self, service: str, path: str):
 
+        service = service.lower()
         self._logger.debug(f"Requesting MQTT service info @ {self._catalogURL}/catalog/services/{service}")
         r = requests.get(url=f"{self._catalogURL}/catalog/services/{service}")
         if r.status_code != 200:
@@ -104,6 +105,7 @@ class CatalogRequest:
 
         RetType = namedtuple("RetType", "status json_response code_response")
         CacheType = namedtuple("CacheType", "header response")
+        service = service.lower()
 
         try:
             self._logger.debug(f"Requesting REST service info @ {self._catalogURL}/catalog/services/{service}")

--- a/src/common/Service.py
+++ b/src/common/Service.py
@@ -11,6 +11,7 @@ class ServiceType(WIOTEnum):
 
 class ServiceSubType(WIOTEnum):
     RASPBERRY = 1
+    ARDUINO   = 2
 
 
 class Service:
@@ -26,8 +27,8 @@ class Service:
             EndpointType.REST.name: {}
         }
 
-        if not (stype == ServiceType.SERVICE != subtype is None):
-            raise ValueError("type and subtype error")
+        if stype == ServiceType.SERVICE and not subtype is None:
+            raise ValueError("Service type and subtype error")
 
     def addEndpoint(self, endpoint: Endpoint):
 
@@ -67,7 +68,7 @@ class Service:
         
         name = d["name"]
         stype = ServiceType.value_of(d["stype"])
-        subtype = ServiceType.value_of(d["subtype"])
+        subtype = ServiceSubType.value_of(d["subtype"])
         epoints_rest = [Endpoint.fromDict(e, EndpointType.REST) for e in d["endpoints"][EndpointType.REST.name].get("list", [])]
         epoints_mqtt = [Endpoint.fromDict(e, EndpointType.MQTT) for e in d["endpoints"][EndpointType.MQTT.name]]
         # host = dict(d["endpoints"][EndpointType.REST.name]).get("host", None)


### PR DESCRIPTION
- [x] Fix Service Type and Subtype cheks in Service class
- [x] Fix use of lower case Service in `CatalogRequest`
- [x] Add new Catalog endpoints: `/catalog/services?stype={service,device}` and `/catalog/services?stype={service,device}&subtype={raspberry,arduino}`