### PR TITLE
Arduino Device Connector

### DIFF
--- a/src/arduinofw/ArduinoI2C/.gitignore
+++ b/src/arduinofw/ArduinoI2C/.gitignore
@@ -1,0 +1,6 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+.vscode/**

--- a/src/arduinofw/ArduinoI2C/include/README
+++ b/src/arduinofw/ArduinoI2C/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/src/arduinofw/ArduinoI2C/lib/README
+++ b/src/arduinofw/ArduinoI2C/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/src/arduinofw/ArduinoI2C/platformio.ini
+++ b/src/arduinofw/ArduinoI2C/platformio.ini
@@ -1,0 +1,14 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino

--- a/src/arduinofw/ArduinoI2C/src/main.cpp
+++ b/src/arduinofw/ArduinoI2C/src/main.cpp
@@ -1,0 +1,23 @@
+#include <Arduino.h>
+#include <Wire.h>
+
+void onRecv(int ln) {
+
+	while(Wire.available()) {
+		if (Wire.read() == 0x0) {
+			PORTB &= ~(1 << 5);
+			PORTB |= (Wire.read() & 0x1) << 5;
+		}
+	}
+
+}
+
+void setup() {
+	DDRB |= (1 << 5);
+	Wire.begin(0x8);
+	Wire.onReceive(onRecv);
+}
+
+void loop() {
+    
+}

--- a/src/arduinofw/ArduinoI2C/test/README
+++ b/src/arduinofw/ArduinoI2C/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html

--- a/src/common/RESTBase.py
+++ b/src/common/RESTBase.py
@@ -9,13 +9,16 @@ class RESTBase:
     def __init__(self, upperRESTSrvcApp: object, indent_lvl: int) -> None:
         self._upperRESTSrvcApp = upperRESTSrvcApp;
 
-    def asjson(self, data: dict):
+    def asjson(self, data: dict, statuscode: int = 200):
+        cherrypy.response.status = statuscode
         return data
 
-    def asjson_error(self, data):
+    def asjson_error(self, data, statuscode: int = 400):
+        cherrypy.response.status = statuscode
         return {"error": data}
     
-    def asjson_info(self, data):
+    def asjson_info(self, data, statuscode: int = 200):
+        cherrypy.response.status = statuscode
         return {"info": data}
 
     @cherrypy.tools.json_out()

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       timeout: 2s
       retries: 5
 
-
   catalog:
     build: 
       context: ./
@@ -23,7 +22,6 @@ services:
       timeout: 2s
       retries: 5
 
-
   calculator:
     build: 
       context: ./
@@ -35,6 +33,18 @@ services:
           condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "curl -f -Li catalog:8080/catalog/services/calculator | grep online | grep -c true"]
+      interval: 15s
+      timeout: 2s
+      retries: 5
+
+  arduinodevconn:
+    build: 
+      context: ./
+      dockerfile: ./services/arduinodevconn/Dockerfile
+    ports:
+      - "8086:8086"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f -Li catalog:8080/catalog/services/arduinodevconn | grep online | grep -c true"]
       interval: 15s
       timeout: 2s
       retries: 5

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -48,3 +48,7 @@ services:
       interval: 15s
       timeout: 2s
       retries: 5
+    devices:
+      - "/dev/i2c-1:/dev/i2c-1"  
+    environment:
+      - ONRASPBERRY=${ONRASPBERRY}

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       interval: 15s
       timeout: 2s
       retries: 5
-    devices:
-      - "/dev/i2c-1:/dev/i2c-1"  
+    # devices:
+    #   - "/dev/i2c-1:/dev/i2c-1"  
     environment:
       - ONRASPBERRY=${ONRASPBERRY}

--- a/src/services/arduinodevconn/Dockerfile
+++ b/src/services/arduinodevconn/Dockerfile
@@ -5,7 +5,8 @@ COPY services/arduinodevconn/requirements.txt /app/services/arduinodevconn/requi
 RUN pip3 install -r /app/common/requirements.txt
 RUN pip3 install -r /app/services/arduinodevconn/requirements.txt
 
-COPY . /app
+COPY ./common /app/common
+COPY ./services /app/services
 WORKDIR /app/services/arduinodevconn
 
 # RUN pip install pipreqs

--- a/src/services/arduinodevconn/Dockerfile
+++ b/src/services/arduinodevconn/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3
+
+COPY common/requirements.txt /app/common/requirements.txt
+COPY services/arduinodevconn/requirements.txt /app/services/arduinodevconn/requirements.txt
+RUN pip3 install -r /app/common/requirements.txt
+RUN pip3 install -r /app/services/arduinodevconn/requirements.txt
+
+COPY . /app
+WORKDIR /app/services/arduinodevconn
+
+# RUN pip install pipreqs
+# RUN pipreqs 
+
+ENV PYTHONPATH=/app
+ENTRYPOINT ["python3", "app.py"]

--- a/src/services/arduinodevconn/Makefile
+++ b/src/services/arduinodevconn/Makefile
@@ -1,0 +1,6 @@
+.PHONY: genreq
+
+genreq: requirements.txt
+
+requirements.txt: *.py
+	@pipreqs --force

--- a/src/services/arduinodevconn/app.py
+++ b/src/services/arduinodevconn/app.py
@@ -38,13 +38,11 @@ class ArduinoDevConnAPI(RESTBase):
             if path[0] == "switch":
 
                 if not "state" in args:
-                    cherrypy.response.status = 400
-                    return self.asjson_error("Missing state argument")
+                    return self.asjson_error("Missing state argument", 400)
 
                 st = str(args["state"]).lower()
                 if st != "on" and st != "off":
-                    cherrypy.response.status = 400
-                    return self.asjson_error("Valid states are: {on, off}")
+                    return self.asjson_error("Valid states are: {on, off}", 400)
 
                 self.logger.info(f"Arduino: switching {st}")
 
@@ -57,8 +55,7 @@ class ArduinoDevConnAPI(RESTBase):
 
                 return self.asjson(r)
 
-        cherrypy.response.status = 404
-        return self.asjson_error("invalid request")
+        return self.asjson_error("invalid request", 404)
 
 class App(WIOTRestApp):
     def __init__(self) -> None:

--- a/src/services/arduinodevconn/app.py
+++ b/src/services/arduinodevconn/app.py
@@ -41,12 +41,11 @@ class ArduinoDevConnAPI(RESTBase):
                     cherrypy.response.status = 400
                     return self.asjson_error("Missing state argument")
 
-                state = str(args["state"]).lower()
-                if state != "on" and state != "off":
+                st = str(args["state"]).lower()
+                if st != "on" and st != "off":
                     cherrypy.response.status = 400
                     return self.asjson_error("Valid states are: {on, off}")
 
-                st = "on" if state == "on" else "off"
                 self.logger.info(f"Arduino: switching {st}")
 
                 if self._onrpi:

--- a/src/services/arduinodevconn/app.py
+++ b/src/services/arduinodevconn/app.py
@@ -46,8 +46,10 @@ class ArduinoDevConnAPI(RESTBase):
 
                 # Do things
                 is_on = st == "on" # to change w raspberry
+                r = {"is_on": is_on}
+                self._catreq.publishMQTT("ArduinoDevConn", "/switch", json.dumps(r))
 
-                return self.asjson({"is_on": is_on})
+                return self.asjson(r)
 
         cherrypy.response.status = 404
         return self.asjson_error("invalid request")
@@ -62,6 +64,7 @@ class App(WIOTRestApp):
             self._settings = SettingsManager.json2obj(SettingsManager.relfile2abs("settings.json"), self.logger)
             self.create(self._settings, "ArduinoDevConn", ServiceType.DEVICE, ServiceSubType.ARDUINO)
             self.addRESTEndpoint("/switch", [EndpointParam("state")])
+            self.addMQTTEndpoint("/switch", "updates on switch status")
 
             self.mount(ArduinoDevConnAPI(self, self._settings), self.conf)
             self.loop()

--- a/src/services/arduinodevconn/app.py
+++ b/src/services/arduinodevconn/app.py
@@ -1,0 +1,74 @@
+import io
+import logging
+import cherrypy
+
+from common.WIOTRestApp import *
+from common.SettingsManager import *
+from common.SettingsNode import *
+from common.RESTBase import RESTBase
+from common.CatalogRequest import *
+
+class ArduinoDevConnAPI(RESTBase):
+
+    def __init__(self, upperRESTSrvcApp, settings: SettingsNode) -> None:
+        super().__init__(upperRESTSrvcApp, 0)
+        self._catreq = CatalogRequest(self.logger, settings)
+
+        self._onrpi = False
+        try:
+            with io.open('/sys/firmware/devicetree/base/model', 'r') as m:
+                if 'raspberry pi' in m.read().lower(): 
+                    self._onrpi = True
+        except Exception: 
+            pass
+
+        if self._onrpi:
+            # setup connection to arduino
+            pass
+
+    @cherrypy.tools.json_out()
+    def GET(self, *path, **args):
+
+        if len(path) > 0:
+            if path[0] == "switch":
+
+                if not "state" in args:
+                    cherrypy.response.status = 400
+                    return self.asjson_error("Missing state argument")
+
+                state = str(args["state"]).lower()
+                if state != "on" and state != "off":
+                    cherrypy.response.status = 400
+                    return self.asjson_error("Valid states are: {on, off}")
+
+                st = "on" if state == "on" else "off"
+                self.logger.info(f"Arduino: switching {st}")
+
+                # Do things
+                is_on = st == "on" # to change w raspberry
+
+                return self.asjson({"is_on": is_on})
+
+        cherrypy.response.status = 404
+        return self.asjson_error("invalid request")
+
+class App(WIOTRestApp):
+    def __init__(self) -> None:
+
+        super().__init__(log_stdout_level=logging.INFO)
+
+        try:
+
+            self._settings = SettingsManager.json2obj(SettingsManager.relfile2abs("settings.json"), self.logger)
+            self.create(self._settings, "ArduinoDevConn", ServiceType.DEVICE, ServiceSubType.ARDUINO)
+            self.addRESTEndpoint("/switch", [EndpointParam("state")])
+
+            self.mount(ArduinoDevConnAPI(self, self._settings), self.conf)
+            self.loop()
+
+        except Exception as e:
+            self.logger.exception(str(e))
+
+
+if __name__ == "__main__":
+    App()

--- a/src/services/arduinodevconn/settings.json
+++ b/src/services/arduinodevconn/settings.json
@@ -8,5 +8,9 @@
         "host": "catalog",
         "port": 8080,
         "ping_ms": 2000
+    },
+    "arduino": {
+        "i2c_dev": 1,
+        "i2c_addr": "0x08"
     }
 }

--- a/src/services/arduinodevconn/settings.json
+++ b/src/services/arduinodevconn/settings.json
@@ -1,0 +1,12 @@
+{
+    "rest_server": {
+        "host": "0.0.0.0",
+        "port": 8086
+    },
+    "indent_level": 4,
+    "catalog": {
+        "host": "catalog",
+        "port": 8080,
+        "ping_ms": 2000
+    }
+}


### PR DESCRIPTION
### Added arduino device connector service.

- **Can run on a normal PC as a dummy device**
- /src/arduinofw contains a platformio.io project containing the firmware to load into an Arduino
- the `arduinodevconn` exposes a REST endpoint `/switch?state={on,off}` and publishes on the MQTT topic `/ArduinoDevConn/switch`
- Raspberry connects to the Arduino via I2C
- Need to load environmental script if running on the Raspberry in order to enable it
- On raspberry, uncomment "devices" part in docker-compose.yml