### PR TITLE
WIOThread: new class for creating threads

### DIFF
--- a/src/common/PingCatalog.py
+++ b/src/common/PingCatalog.py
@@ -3,7 +3,7 @@ import logging
 import requests
 
 from common.Service import *
-from threading import Thread, Event
+from common.WIOThread import WIOThread
 
 class PingCatalog:
 
@@ -15,16 +15,13 @@ class PingCatalog:
         self._ping_time_ms = ping_time_ms        
         self._logger = logger
 
-        self._th1_evtstop = Event()
-        self._th1_evtstart = Event()
-        self._th1 = Thread(target=self._thread_pinger, name="PingCatalog: Thread Pinger")
+        self._th = WIOThread(target=self._thread_pinger, name="PingCatalog: Thread Pinger")
 
     def _thread_pinger(self):
         self._logger.info("Catalog Pinger started")
-        self._th1_evtstart.set()
 
         time.sleep(0.5)
-        while not self._th1_evtstop.is_set():
+        while not self._th.is_stop_requested:
 
             self._logger.debug(f"Sending ping to Catalog {self._catalogHost}:{self._catalogPort}")
 
@@ -36,19 +33,12 @@ class PingCatalog:
             except Exception as e:
                 self._logger.error(f"Unable to send ping: {str(e)}")
 
-            self._th1_evtstop.wait(self._ping_time_ms / 1e3)
+            self._th.wait(self._ping_time_ms / 1e3)
 
     def run(self):
-        self._th1_evtstop.clear()
-        self._th1_evtstart.clear()
-        self._th1.start()
+        self._th.run()
 
     def stop(self):
-
-        if not self._th1_evtstart.is_set():
-            return
-
-        self._th1_evtstop.set()
-        self._th1.join()
+        self._th.stop()
         self._logger.info("Catalog Pinger stopped")
 

--- a/src/common/WIOThread.py
+++ b/src/common/WIOThread.py
@@ -1,0 +1,37 @@
+
+from threading import Thread, Event
+
+class WIOThread:
+
+    def __init__(self, target, name: str = None) -> None:
+        
+        self._evtstop = Event()
+        self._evtstart = Event()
+        self._th = Thread(target=self._thread_fnc, name=name)
+        self._target = target
+
+    def _thread_fnc(self):
+
+        self._evtstart.set()
+        while not self._evtstop.is_set():
+            self._target()
+
+    def run(self):
+        self._evtstop.clear()
+        self._evtstart.clear()
+        self._th.start()
+
+    def stop(self):
+
+        if not self._evtstart.is_set():
+            return
+
+        self._evtstop.set()
+        self._th.join()
+
+    def wait(self, delay_seconds):
+        self._evtstop.wait(delay_seconds)
+
+    @property
+    def is_stop_requested(self) -> bool:
+        return self._evtstop.is_set()

--- a/src/services/catalog/ServiceManager.py
+++ b/src/services/catalog/ServiceManager.py
@@ -1,11 +1,12 @@
 import copy
 import logging
 
-from threading import Thread, Lock, Event
+from threading import Lock
 from time import sleep, time
 
 from common.SettingsNode import SettingsNode
 from common.Service import Service
+from common.WIOThread import WIOThread
 
 class ServiceManager:
 
@@ -15,16 +16,15 @@ class ServiceManager:
         self._services = dict[str, Service]()
         self._dead_services = dict[str, Service]()
         self._lock = Lock()
-        self._th1_evtstop = Event()
 
-        self._th1 = Thread(target=self._thread_cleaner, name="ServiceManager: Thread Cleaner")
+        self._th1 = WIOThread(target=self._thread_cleaner, name="ServiceManager: Thread Cleaner")
 
     def _thread_cleaner(self):
 
         self._logger.info("Catalog Watchdog started")
 
         sleep(0.5)
-        while not self._th1_evtstop.is_set():
+        while not self._th1.is_stop_requested:
             self._lock.acquire()
             tm = time()
 
@@ -33,18 +33,16 @@ class ServiceManager:
                 if tm - s.timestamp >= self._settings.watchdog.expire_sec:
                     dead = self._services.pop(s.name)
                     self._dead_services[dead.name] = dead
-                    self._logger.info(f"Service {s.name} expired")
+                    self._logger.warn(f"Service {s.name} expired")
 
             self._lock.release()
-            self._th1_evtstop.wait(self._settings.watchdog.timeout_ms / 1e3)
+            self._th1.wait(self._settings.watchdog.timeout_ms / 1e3)
 
     def run_watchdog(self):
-        self._th1_evtstop.clear()
-        self._th1.start()
+        self._th1.run()
 
     def stop_watchdog(self):
-        self._th1_evtstop.set()
-        self._th1.join()
+        self._th1.stop()
         self._logger.info("Catalog Watchdog stopped")
 
     def add_service(self, service: Service):

--- a/src/services/openweatheradaptor/app.py
+++ b/src/services/openweatheradaptor/app.py
@@ -53,7 +53,7 @@ class OpenWeatherAPI(RESTBase):
 class App(WIOTRestApp):
     def __init__(self) -> None:
 
-        super().__init__(log_stdout_level=logging.DEBUG)
+        super().__init__(log_stdout_level=logging.INFO)
 
         try:
 


### PR DESCRIPTION
In order to use it you can do something like this:

```python
from common.WIOThread import WIOThread

class MyAPI(RESTBase):

    def __init__(self, upperRESTSrvcApp: WIOTRestApp, settings: SettingsNode) -> None:
        super().__init__(upperRESTSrvcApp, 0)
        self._catreq = CatalogRequest(self.logger, settings)

        self._th = WIOThread(target=self._threadfnc, name="My beatiful thread") # Crates the thread
        upperRESTSrvcApp.subsribe_evt_stop(self._th.stop)                       # Subscribe the stop function to the CherryPy Handler
        self._th.run()                                                          # Starts running the thread

    def _threadfnc(self):
        while not self._th.is_stop_requested:                                   # Executes 'till a stop is requested
            self._th.wait(1)                                                    # Stops the thread for a given amount of seconds
            self.logger.info("HOLAAAAAAAAAA")

    @cherrypy.tools.json_out()
    def GET(self, *path, **args):
        pass

```
   
@giop98 this can be useful for your RaspberryPi Device Connector service!